### PR TITLE
support for Optional[`a]

### DIFF
--- a/lib/Mew.pm
+++ b/lib/Mew.pm
@@ -23,13 +23,22 @@ sub import {
         my @name_proto = ref $name_proto eq 'ARRAY'
             ? @$name_proto : $name_proto;
 
+        my $req = 1;
         my $mew_type;
         $mew_type = shift if @_ % 2 != 0;
+        if ($mew_type and $mew_type->is_parameterized and $mew_type->parent == Types::Standard::Optional()) {
+            $req = 0;
+            $mew_type = $mew_type->type_parameter;
+        }
+        elsif ($mew_type and $mew_type == Types::Standard::Optional()) {
+            $req = 0;
+            $mew_type = Types::Standard::Any();
+        }
         for my $attr ( @name_proto ) {
             my %spec = @_;
             if ( $mew_type ) {
                 my %mew_spec;
-                $mew_spec{required} = 1 unless $attr =~ s/^-//;
+                $mew_spec{required} = $req unless $attr =~ s/^-//;
                 ( $mew_spec{init_arg} = $attr ) =~ s/^_//
                     unless exists $spec{init_arg};
 
@@ -230,6 +239,10 @@ It's possible to alter the defaults created by C<Mew>:
 
 Simply prefix the attribute's name with a minus sign to avoid setting
 C<< required => 1 >>.
+
+Alternatively, use the C<Optional> type provided by Types::Standard.
+
+    has _cust => Optional[Str];
 
 =head4 Modify other options
 

--- a/t/02-optional.t
+++ b/t/02-optional.t
@@ -1,0 +1,48 @@
+#!perl
+
+use strict;
+use warnings FATAL => 'all';
+use Test::Most;
+
+BEGIN { use_ok 't::Class2' };
+
+throws_ok { t::Class2->new } qr/Missing required arguments: ar1, num/,
+    'required args checked';
+
+throws_ok { t::Class2->new( num => "zof", ar1 => 'var1' ) }
+    qr/Must be a positive number/,
+    'type is checked';
+
+{
+    my $c = t::Class2->new( num => 42, initizer => 'zoom!', ar1 => '42' );
+    is $c->_num,  42,          '->_num is correct';
+    is $c->_type, 'text/html', '->_type is correct';
+    is $c->_cust, 'Zoffix',    '->_cust is correct';
+    is $c->_init, 'zoom!',     '->_init is correct (custom init_arg)';
+    ok ! defined $c->_bool,    '->_bool is correct (undefined)';
+
+    isa_ok $c->chained("foo")->chained2( 45 ), 't::Class2',
+        'chained attributes return invocants';
+
+    is $c->chained, "foo", 'chained attributes update values';
+    is $c->chained2, 45,   'chained attributes update values';
+}
+
+{
+    my $c = t::Class2->new(
+        num   => 43,
+        bool  => 1,
+        _cust => 'Bar',
+        type  => 'fo',
+        ar1   => 'var1',
+        ar2   => 'var2',
+    );
+    is $c->_num,  43,     '->_num is correct';
+    is $c->_type, 'fo',   '->_type is correct';
+    is $c->_cust, 'Bar',  '->_cust is correct';
+    is $c->_bool, 1,      '->_bool is correct';
+    is $c->ar1,   'var1', '->ar1 is correct';
+    is $c->_ar2,  'var2', '->_ar2 is correct';
+}
+
+done_testing;

--- a/t/Class2.pm
+++ b/t/Class2.pm
@@ -1,0 +1,15 @@
+package t::Class2;
+
+use Mew;
+
+has _num     => PositiveNum;
+has _bool    => Optional[Bool];
+has _type    => ( Str, default => 'text/html');
+has _init    => ( Optional[Str], init_arg => 'initizer');
+has chained  => ( Optional[Str], chained => 1 );
+has chained2 => ( Optional[Num], chained => 1 );
+
+has [qw/ar1 -_ar2/] => Str;
+
+has _cust => ( is => 'rw', default => 'Zoffix' );
+1;


### PR DESCRIPTION
Adds support for:

      has foo => Optional[Int];